### PR TITLE
`@AccountKey`: support nested types

### DIFF
--- a/Sources/SpeziAccountMacros/AccountKeyMacro.swift
+++ b/Sources/SpeziAccountMacros/AccountKeyMacro.swift
@@ -145,10 +145,10 @@ extension AccountKeyMacro: PeerMacro {
             accountKeyProtocol = "RequiredAccountKey"
         }
 
-        guard valueTypeInitializer.as(IdentifierTypeSyntax.self)?.name.text == valueTypeName.forceToText else {
+        guard valueTypeInitializer.forceToText == valueTypeName.forceToText else {
             throw DiagnosticsError(
                 syntax: valueTypeName,
-                message: "Value type '\(valueTypeName) is expected to match the property binding type annotation '\(valueTypeInitializer.as(IdentifierTypeSyntax.self)?.name.text ?? "<<unknown>>")'",
+                message: "Value type '\(valueTypeName)' is expected to match the property binding type annotation '\(valueTypeInitializer.forceToText)'",
                 id: .invalidApplication
             )
         }
@@ -369,7 +369,7 @@ extension LabeledExprSyntax {
 }
 
 
-extension ExprSyntaxProtocol {
+extension SyntaxProtocol {
     var forceToText: String {
         String(decoding: syntaxTextBytes, as: UTF8.self)
     }

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable function_body_length file_length type_body_length
+
 #if os(macOS) // macro tests can only be run on the host machine
 import SpeziAccountMacros
 import SwiftSyntaxMacroExpansion
@@ -19,7 +21,7 @@ let testMacrosSpecs: [String: MacroSpec] = [
 ]
 
 @Suite("AccountKeyMacro Tests")
-struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
+struct AccountKeyMacroTests {
     @Test
     func testAccountKeyGeneration() {
         assertMacroExpansion(
@@ -210,7 +212,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
-    func testCustomUI() { // swiftlint:disable:this function_body_length
+    func testCustomUI() {
         assertMacroExpansion(
             """
             extension AccountDetails {
@@ -292,7 +294,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
-    func testCustomUINameCollision() { // swiftlint:disable:this function_body_length
+    func testCustomUINameCollision() {
         assertMacroExpansion(
             """
             extension AccountDetails {
@@ -378,7 +380,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
-    func testAccountKeyOptions() { // swiftlint:disable:this function_body_length
+    func testAccountKeyOptions() {
         assertMacroExpansion(
             """
             extension AccountDetails {
@@ -552,7 +554,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
-    func testAccountKeyOptionsDiagnostics() { // swiftlint:disable:this function_body_length
+    func testAccountKeyOptionsDiagnostics() {
         assertMacroExpansion(
             """
             extension AccountDetails {
@@ -716,7 +718,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
-    func testGeneralDiagnostics() { // swiftlint:disable:this function_body_length
+    func testGeneralDiagnostics() {
         assertMacroExpansion(
             """
             @AccountKey(
@@ -807,8 +809,45 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
             failureHandler: { Issue.record("\($0.message)") }
         )
     }
+    
+    @Test
+    func accountKeyNestedType() {
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Preferred Workout Type", category: .personalDetails, as: WorkoutType.ID.self, initial: .default(""))
+                var preferredWorkoutType: WorkoutType.ID?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var preferredWorkoutType: WorkoutType.ID? {
+                    get {
+                        self[__Key_preferredWorkoutType.self]
+                    }
+                    set {
+                        self[__Key_preferredWorkoutType.self] = newValue
+                    }
+                }
+            
+                struct __Key_preferredWorkoutType: AccountKey {
+                    typealias Value = WorkoutType.ID
+            
+                    static let name: LocalizedStringResource = "Preferred Workout Type"
+                    static let identifier: String = "preferredWorkoutType"
+                    static let category: AccountKeyCategory = .personalDetails
+                    static var initialValue: InitialValue<Value> {
+                        .default("")
+                    }
+                    static let options: AccountKeyOptions = .default
+                }
+            }
+            """,
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+    }
 }
 
 #endif
-
-// swiftlint:disable:this file_length

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -204,7 +204,7 @@ struct AccountKeyMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "Value type 'Int is expected to match the property binding type annotation 'String'", line: 2, column: 65)
+                DiagnosticSpec(message: "Value type 'Int' is expected to match the property binding type annotation 'String'", line: 2, column: 65)
             ],
             macroSpecs: testMacrosSpecs,
             failureHandler: { Issue.record("\($0.message)") }

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -230,8 +230,8 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
 
         XCTAssertTrue(app.staticTexts["Sent out a link to reset the password."].waitForExistence(timeout: 3.0))
 
-        XCTAssertTrue(app.buttons["Cancel"].exists)
-        app.buttons["Cancel"].tap()
+        XCTAssertTrue(app.buttons["Done"].exists)
+        app.buttons["Done"].tap()
 
         XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 2.0))
         app.buttons["Close"].tap()


### PR DESCRIPTION
# `@AccountKey`: support nested types

## :recycle: Current situation & Problem
the `@AccountKey` macro currently does not support nested types


## :gear: Release Notes
- `@AccountKey`: support nested types (fixes #101)
- the `PasswordResetView`'s now dynamically switches between a "Cancel" and "Done" toolbar item, based on the view's state (instead of always showing "Cancel")


## :books: Documentation
n/a


## :white_check_mark: Testing
we have a new test case


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- x ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
