### PR TITLE
add "will log out" account event; custom deletion hooks for the AccountOverview

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.2.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.2"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.12.4"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.12.9"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "2.0.0"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),

--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -182,7 +182,7 @@ public final class Account {
                 if let previousDetails {
                     try await notifications.reportEvent(.detailsChanged(previousDetails, details))
                 } else {
-                    try await notifications.reportEvent(.didAssociate(details))
+                    try await notifications.reportEvent(.associatedAccount(details))
                 }
             } catch {
                 logger.error("Account Association event failed unexpectedly: \(error)")
@@ -199,7 +199,7 @@ public final class Account {
         if let details {
             Task { @MainActor [notifications, details] in
                 do {
-                    try await notifications.reportEvent(.didDisassociate(details))
+                    try await notifications.reportEvent(.disassociatingAccount(details))
                 } catch {
                     logger.error("Account Disassociation event failed unexpectedly: \(error)")
                 }

--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -182,7 +182,7 @@ public final class Account {
                 if let previousDetails {
                     try await notifications.reportEvent(.detailsChanged(previousDetails, details))
                 } else {
-                    try await notifications.reportEvent(.associatedAccount(details))
+                    try await notifications.reportEvent(.didAssociate(details))
                 }
             } catch {
                 logger.error("Account Association event failed unexpectedly: \(error)")
@@ -199,14 +199,12 @@ public final class Account {
         if let details {
             Task { @MainActor [notifications, details] in
                 do {
-                    try await notifications.reportEvent(.disassociatingAccount(details))
+                    try await notifications.reportEvent(.didDisassociate(details))
                 } catch {
                     logger.error("Account Disassociation event failed unexpectedly: \(error)")
                 }
             }
         }
-
-
         if signedIn {
             signedIn = false
         }

--- a/Sources/SpeziAccount/AccountNotifications.swift
+++ b/Sources/SpeziAccount/AccountNotifications.swift
@@ -26,19 +26,36 @@ import Spezi
 public final class AccountNotifications {
     /// Describes an Account event.
     public enum Event {
+        /// A new account was associated due to a login or signup operation.
+        case didAssociate(_ details: AccountDetails)
+        /// The details of the currently associated Account changed.
+        case detailsChanged(_ previous: AccountDetails, _ new: AccountDetails)
+        /// The current account is about to be logged out.
+        case willLogOut(_ details: AccountDetails)
+        /// The account with the given details is being disassociated (e.g., because it was logged out or deleted).
+        case didDisassociate(_ details: AccountDetails)
         /// The currently associated user account is about to be deleted.
         ///
         /// This event signals that the user requested to have their account deleted and the user's data is about to be deleted.
         ///
         /// - Note: Make sure to report this event before the account is deleted. Deletion might be forwarded to an external ``AccountStorageProvider`` which
         ///     might report an error if it fails to fully delete the associated user data.
-        case deletingAccount(_ accountId: String)
-        /// A new account was associated due to a login or signup operation.
-        case associatedAccount(_ details: AccountDetails)
-        /// The details of the currently associated Account changed.
-        case detailsChanged(_ previous: AccountDetails, _ new: AccountDetails)
-        /// The account with the given details is being disassociated (e.g., logout or deletion).
-        case disassociatingAccount(_ details: AccountDetails)
+        case willDelete(_ accountId: String)
+        
+        @available(*, unavailable, renamed: "willDelete")
+        public static func deletingAccount(_ accountId: String) -> Self {
+            .willDelete(accountId)
+        }
+        
+        @available(*, unavailable, renamed: "didAssociate")
+        public static func associatedAccount(_ details: AccountDetails) -> Self {
+            .didAssociate(details)
+        }
+        
+        @available(*, unavailable, renamed: "didDisassociate")
+        public static func disassociatingAccount(_ details: AccountDetails) -> Self {
+            .didDisassociate(details)
+        }
     }
 
     @StandardActor private var standard: any Standard
@@ -77,10 +94,10 @@ public final class AccountNotifications {
         await notifyStandard?.respondToEvent(event)
 
         switch event {
-        case let .deletingAccount(accountId):
+        case let .willDelete(accountId):
             try await storage.willDeleteAccount(for: accountId)
-        case let .disassociatingAccount(details):
-            await storage.userWillDisassociate(for: details.accountId)
+        case let .didDisassociate(details):
+            await storage.userDidDisassociate(for: details.accountId)
         default:
             break
         }

--- a/Sources/SpeziAccount/AccountNotifications.swift
+++ b/Sources/SpeziAccount/AccountNotifications.swift
@@ -23,50 +23,37 @@ import Spezi
 /// ### Reporting events
 /// Report events when implementing an `AccountService`.
 /// - ``reportEvent(_:)``
-public final class AccountNotifications {
+public final class AccountNotifications: Module, DefaultInitializable, EnvironmentAccessible, @unchecked Sendable {
     /// Describes an Account event.
-    public enum Event {
+    public enum Event: Sendable {
         /// A new account was associated due to a login or signup operation.
-        case didAssociate(_ details: AccountDetails)
+        ///
+        /// - Note: This enum case will be renamed to `didAssociate` in a future release.
+        case associatedAccount(_ details: AccountDetails)
         /// The details of the currently associated Account changed.
         case detailsChanged(_ previous: AccountDetails, _ new: AccountDetails)
-        /// The current account is about to be logged out.
-        case willLogOut(_ details: AccountDetails)
         /// The account with the given details is being disassociated (e.g., because it was logged out or deleted).
-        case didDisassociate(_ details: AccountDetails)
+        ///
+        /// - Note: This enum case will be renamed to `didDisassociate` in a future release.
+        case disassociatingAccount(_ details: AccountDetails)
         /// The currently associated user account is about to be deleted.
         ///
         /// This event signals that the user requested to have their account deleted and the user's data is about to be deleted.
         ///
         /// - Note: Make sure to report this event before the account is deleted. Deletion might be forwarded to an external ``AccountStorageProvider`` which
         ///     might report an error if it fails to fully delete the associated user data.
-        case willDelete(_ accountId: String)
-        
-        @available(*, unavailable, renamed: "willDelete")
-        public static func deletingAccount(_ accountId: String) -> Self {
-            .willDelete(accountId)
-        }
-        
-        @available(*, unavailable, renamed: "didAssociate")
-        public static func associatedAccount(_ details: AccountDetails) -> Self {
-            .didAssociate(details)
-        }
-        
-        @available(*, unavailable, renamed: "didDisassociate")
-        public static func disassociatingAccount(_ details: AccountDetails) -> Self {
-            .didDisassociate(details)
-        }
+        ///
+        /// - Note: This enum case will be renamed to `willDelete` in a future release.
+        case deletingAccount(_ accountId: String)
     }
 
     @StandardActor private var standard: any Standard
-
-    @Dependency(ExternalAccountStorage.self)
-    private var storage
-
     private var notifyStandard: (any AccountNotifyConstraint)? {
         standard as? any AccountNotifyConstraint
     }
 
+    @Dependency(ExternalAccountStorage.self)
+    private var storage
 
     private var subscriptions: [UUID: AsyncStream<Event>.Continuation] = [:]
     private let lock = NSLock()
@@ -92,16 +79,14 @@ public final class AccountNotifications {
     @MainActor
     public func reportEvent(_ event: Event) async throws {
         await notifyStandard?.respondToEvent(event)
-
         switch event {
-        case let .willDelete(accountId):
+        case let .deletingAccount(accountId):
             try await storage.willDeleteAccount(for: accountId)
-        case let .didDisassociate(details):
+        case let .disassociatingAccount(details):
             await storage.userDidDisassociate(for: details.accountId)
         default:
             break
         }
-
         lock.withLock {
             for subscription in subscriptions.values {
                 subscription.yield(event)
@@ -116,7 +101,6 @@ public final class AccountNotifications {
             lock.withLock {
                 subscriptions[id] = continuation
             }
-
             continuation.onTermination = { [weak self, id] _ in
                 guard let self else {
                     return
@@ -128,9 +112,3 @@ public final class AccountNotifications {
         }
     }
 }
-
-
-extension AccountNotifications.Event: Sendable {}
-
-
-extension AccountNotifications: Module, DefaultInitializable, EnvironmentAccessible, @unchecked Sendable {}

--- a/Sources/SpeziAccount/AccountNotifyConstraint.swift
+++ b/Sources/SpeziAccount/AccountNotifyConstraint.swift
@@ -20,8 +20,9 @@ import Spezi
 /// actor MyStandard: Standard, AccountNotifyConstraint {
 ///     init() {}
 ///
-///     func respondToEvent(_ event: AccountNotifications.Event) {
-///         if case let .deletingAccount(accountId) {
+///     func handleAccountEvent(_ event: AccountNotifications.Event) {
+///         switch event {
+///         case .deletingAccount(let accountId):
 ///             // handle deletion of associated user data
 ///         }
 ///     }
@@ -32,4 +33,14 @@ public protocol AccountNotifyConstraint: Standard {
     ///
     /// For more information refer to ``AccountNotifications/Event``.
     func respondToEvent(_ event: AccountNotifications.Event) async
+    
+    /// Notifies the standard that the currently logged-in account is about to be logged out.
+    ///
+    /// - Note: This function will be folded into the ``AccountNotifications/Event`` enum in a future release.
+    func willLogOut(_ details: AccountDetails) async
+}
+
+
+extension AccountNotifyConstraint {
+    public func willLogOut(_ details: AccountDetails) async {}
 }

--- a/Sources/SpeziAccount/AccountNotifyConstraint.swift
+++ b/Sources/SpeziAccount/AccountNotifyConstraint.swift
@@ -42,5 +42,6 @@ public protocol AccountNotifyConstraint: Standard {
 
 
 extension AccountNotifyConstraint {
+    // swiftlint:disable:next missing_docs
     public func willLogOut(_ details: AccountDetails) async {}
 }

--- a/Sources/SpeziAccount/AccountNotifyConstraint.swift
+++ b/Sources/SpeziAccount/AccountNotifyConstraint.swift
@@ -20,7 +20,7 @@ import Spezi
 /// actor MyStandard: Standard, AccountNotifyConstraint {
 ///     init() {}
 ///
-///     func handleAccountEvent(_ event: AccountNotifications.Event) {
+///     func respondToEvent(_ event: AccountNotifications.Event) async {
 ///         switch event {
 ///         case .deletingAccount(let accountId):
 ///             // handle deletion of associated user data

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -71,9 +71,30 @@ public struct AccountOverview<AdditionalSections: View>: View {
         /// Account deletion is not available.
         case disabled
         /// When entering the edit mode, the logout button turns into a delete account button.
-        case inEditMode
+        case inEditMode(Handler)
         /// Show the delete button below the logout button.
-        case belowLogout
+        case belowLogout(Handler)
+        
+        /// When entering the edit mode, the logout button turns into a delete account button.
+        public static var inEditMode: Self {
+            .inEditMode(.default)
+        }
+        
+        /// Show the delete button below the logout button.
+        public static var belowLogout: Self {
+            .belowLogout(.default)
+        }
+        
+        /// How account deletion via the ``AccountOverview`` should be handled.
+        public enum Handler {
+            /// Account deletion should be handled normally via SpeziAccount.
+            case `default`
+            /// Account deletion should be handled via a custom closure.
+            ///
+            /// In this case, if the user attempts to delete the account through the ``AccountOverview``,
+            /// this custom closure will be invoked, instead of the account service' ``AccountService/delete()`` function.
+            case custom(_ handler: @Sendable () async throws -> Void)
+        }
     }
 
     private let closeBehavior: CloseBehavior

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -75,16 +75,6 @@ public struct AccountOverview<AdditionalSections: View>: View {
         /// Show the delete button below the logout button.
         case belowLogout(Handler)
         
-        /// When entering the edit mode, the logout button turns into a delete account button.
-        public static var inEditMode: Self {
-            .inEditMode(.default)
-        }
-        
-        /// Show the delete button below the logout button.
-        public static var belowLogout: Self {
-            .belowLogout(.default)
-        }
-        
         /// How account deletion via the ``AccountOverview`` should be handled.
         public enum Handler {
             /// Account deletion should be handled normally via SpeziAccount.
@@ -94,6 +84,16 @@ public struct AccountOverview<AdditionalSections: View>: View {
             /// In this case, if the user attempts to delete the account through the ``AccountOverview``,
             /// this custom closure will be invoked, instead of the account service' ``AccountService/delete()`` function.
             case custom(_ handler: @Sendable () async throws -> Void)
+        }
+        
+        /// When entering the edit mode, the logout button turns into a delete account button.
+        public static var inEditMode: Self {
+            .inEditMode(.default)
+        }
+        
+        /// Show the delete button below the logout button.
+        public static var belowLogout: Self {
+            .belowLogout(.default)
         }
     }
 

--- a/Sources/SpeziAccount/ExternalAccountStorage.swift
+++ b/Sources/SpeziAccount/ExternalAccountStorage.swift
@@ -180,7 +180,7 @@ public final class ExternalAccountStorage: Module, Sendable {
         try await storageProvider?.delete(accountId)
     }
 
-    func userWillDisassociate(for accountId: String) async {
+    func userDidDisassociate(for accountId: String) async {
         await storageProvider?.disassociate(accountId)
     }
 }

--- a/Sources/SpeziAccount/ExternalAccountStorage.swift
+++ b/Sources/SpeziAccount/ExternalAccountStorage.swift
@@ -38,9 +38,9 @@ public final class ExternalAccountStorage: Module, Sendable {
         public let details: AccountDetails
     }
 
-    private nonisolated(unsafe) weak var storageProvider: (any AccountStorageProvider)?
+    nonisolated(unsafe) private weak var storageProvider: (any AccountStorageProvider)?
 
-    private nonisolated(unsafe) var subscriptions: [UUID: AsyncStream<ExternallyStoredDetails>.Continuation] = [:]
+    nonisolated(unsafe) private var subscriptions: [UUID: AsyncStream<ExternallyStoredDetails>.Continuation] = [:]
     private let lock = NSLock()
 
 

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -134,6 +134,11 @@ public final class InMemoryAccountService: AccountService {
 
     @Application(\.logger)
     private var logger
+    
+    @StandardActor private var standard: any Standard
+    private var notifyStandard: (any AccountNotifyConstraint)? {
+        standard as? any AccountNotifyConstraint
+    }
 
     @Dependency(Account.self)
     private var account
@@ -305,6 +310,9 @@ public final class InMemoryAccountService: AccountService {
     public func logout() async throws {
         logger.debug("Logging out user")
         try await Task.sleep(for: .milliseconds(500))
+        if let details = account.details {
+            await notifyStandard?.willLogOut(details)
+        }
         account.removeUserDetails()
     }
 

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -322,7 +322,7 @@ public final class InMemoryAccountService: AccountService {
         }
 
         let notifications = notifications
-        try await notifications.reportEvent(.deletingAccount(details.accountId))
+        try await notifications.reportEvent(.willDelete(details.accountId))
 
         registeredUsers.removeValue(forKey: details.accountId.assumeUUID)
         userIdToAccountId.removeValue(forKey: details.userId)

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -322,7 +322,7 @@ public final class InMemoryAccountService: AccountService {
         }
 
         let notifications = notifications
-        try await notifications.reportEvent(.willDelete(details.accountId))
+        try await notifications.reportEvent(.deletingAccount(details.accountId))
 
         registeredUsers.removeValue(forKey: details.accountId.assumeUUID)
         userIdToAccountId.removeValue(forKey: details.userId)

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewForm.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewForm.swift
@@ -72,7 +72,7 @@ struct AccountOverviewForm<AdditionalSections: View>: View {
                 // Note how the below AsyncButton (in the HStack) uses the same `destructiveViewState`.
                 // Due to SwiftUI behavior, the alert will be dismissed immediately. We use the AsyncButton here still
                 // to manage our async task and setting the ViewState.
-                AsyncButton(role: .destructive, state: $destructiveViewState, action: {
+                AsyncButton(role: .destructive, state: $destructiveViewState) {
                     do {
                         try await account.accountService.logout()
                     } catch {
@@ -82,7 +82,7 @@ struct AccountOverviewForm<AdditionalSections: View>: View {
                         throw error
                     }
                     dismiss()
-                }) {
+                } label: {
                     Text("UP_LOGOUT", bundle: .module)
                 }
                 .environment(\.defaultErrorDescription, .init("UP_LOGOUT_FAILED_DEFAULT_ERROR", bundle: .atURL(from: .module)))
@@ -93,9 +93,20 @@ struct AccountOverviewForm<AdditionalSections: View>: View {
             }
             .alert(Text("CONFIRMATION_REMOVAL", bundle: .module), isPresented: $model.presentingRemovalAlert) {
                 // see the discussion of the AsyncButton in the above alert closure
-                AsyncButton(role: .destructive, state: $destructiveViewState, action: {
+                AsyncButton(role: .destructive, state: $destructiveViewState) {
                     do {
-                        try await account.accountService.delete()
+                        switch deletionBehavior {
+                        case .disabled:
+                            // unreachable, bc in this case there would be no button
+                            return
+                        case .inEditMode(let handler), .belowLogout(let handler):
+                            switch handler {
+                            case .default:
+                                try await account.accountService.delete()
+                            case .custom(let handler):
+                                try await handler()
+                            }
+                        }
                     } catch {
                         if error is CancellationError {
                             return
@@ -103,7 +114,7 @@ struct AccountOverviewForm<AdditionalSections: View>: View {
                         throw error
                     }
                     dismiss()
-                }) {
+                } label: {
                     Text("DELETE", bundle: .module)
                 }
                 .environment(\.defaultErrorDescription, .init("REMOVE_DEFAULT_ERROR", bundle: .atURL(from: .module)))

--- a/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
@@ -88,3 +88,15 @@ extension XCUIApplication {
     }
 #endif
 }
+
+
+extension XCUIApplication {
+    /// Dismisses an iOS "Save Password?" alert, if one appears within `timeout` seconds.
+    public func dismissSavePasswordAlert(timeout: TimeInterval) {
+        let title = "Save Password?"
+        // fun fact it's actually a sheet even though it looks like an alert.
+        if sheets[title].waitForExistence(timeout: timeout) {
+            sheets[title].buttons["Not Now"].tap()
+        }
+    }
+}

--- a/Tests/UITests/TestApp/Utils/TestStandard.swift
+++ b/Tests/UITests/TestApp/Utils/TestStandard.swift
@@ -28,7 +28,7 @@ actor TestStandard: AccountNotifyConstraint, PhoneVerificationConstraint, Enviro
     struct AccountDetailsError: Error {}
 
     private let storage = Storage()
-    private nonisolated let features: Features
+    nonisolated private let features: Features
 
     @Dependency(Account.self)
     private var account: Account?

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -291,6 +291,8 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         app.collectionViews.buttons["Signup"].tap()
 
         XCTAssertTrue(app.staticTexts[email].waitForExistence(timeout: 4.0))
+        
+        app.dismissSavePasswordAlert(timeout: 2)
 
         // Now verify what we entered
         app.openAccountOverview()


### PR DESCRIPTION
# add "will log out" account event; custom deletion hooks for the AccountOverview

## :recycle: Current situation & Problem
issue: the account events currently are named somewhat misleading (eg `disassociatingAccount` makes it sound like at the time the event is emitted the account is still being disassociated; but in fact the event gets sent out afterwards), and are missing a pre-logout hook (analogously to the pre-deletion event we already have).


## :gear: Release Notes
- added a `willLogOut` function to the `AccountNotifyConstraint`
- added an API to customize (ie, override) the deletion handling in the `AccountOverview`

## :books: Documentation
the new case is documented.


## :white_check_mark: Testing
no


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
