### PR TITLE
fix SpeziAccount testing

### DIFF
--- a/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
@@ -17,7 +17,6 @@ extension XCUIApplication {
     ///   - password: The password credential.
     public func login<Email: StringProtocol, Password: StringProtocol>(email: Email, password: Password) throws {
         try login(userId: email, password: password, field: "E-Mail Address")
-        dismissSavePasswordAlert(timeout: 4)
     }
     
     /// Perform password-credential based login.
@@ -39,5 +38,7 @@ extension XCUIApplication {
         XCTAssertTrue(buttons["Login"].waitForExistence(timeout: 0.5)) // might need time to to get enabled
         XCTAssertTrue(buttons["Login"].isEnabled)
         buttons["Login"].tap()
+        
+        dismissSavePasswordAlert(timeout: 4)
     }
 }

--- a/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
@@ -17,6 +17,7 @@ extension XCUIApplication {
     ///   - password: The password credential.
     public func login<Email: StringProtocol, Password: StringProtocol>(email: Email, password: Password) throws {
         try login(userId: email, password: password, field: "E-Mail Address")
+        dismissSavePasswordAlert(timeout: 4)
     }
     
     /// Perform password-credential based login.

--- a/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
@@ -15,7 +15,7 @@ extension XCUIApplication {
     /// - Parameters:
     ///   - email: The email credential.
     ///   - password: The password credential.
-    public func login<Email: StringProtocol, Password: StringProtocol>(email: Email, password: Password) throws {
+    public func login(email: some StringProtocol, password: some StringProtocol) throws {
         try login(userId: email, password: password, field: "E-Mail Address")
     }
     
@@ -23,12 +23,12 @@ extension XCUIApplication {
     /// - Parameters:
     ///   - username: The username credential.
     ///   - password: The password credential.
-    public func login<Username: StringProtocol, Password: StringProtocol>(username: Username, password: Password) throws {
+    public func logi(username: some StringProtocol, password: some StringProtocol) throws {
         try login(userId: username, password: password, field: "Username")
     }
 
 
-    private func login<UserId: StringProtocol, Password: StringProtocol>(userId: UserId, password: Password, field: String) throws {
+    private func login(userId: some StringProtocol, password: some StringProtocol, field: String) throws {
         XCTAssertTrue(textFields[field].exists)
         XCTAssertTrue(secureTextFields["Password"].exists)
 


### PR DESCRIPTION
# fix SpeziAccount testing

## :recycle: Current situation & Problem
iOS 26.2 presents an "do you want to save this password" alert after logging in to an account; this PR adjusts XCTSpeziAccount's `login` function to auto-dismiss this alert


## :gear: Release Notes
- handle iOS 26.2 password manager alert


## :books: Documentation
n/a


## :white_check_mark: Testing
fixed (hopefully)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
