### PR TITLE
feat: replace inline delete button with swipe-to-delete for phone numbers

### DIFF
--- a/Sources/SpeziAccountPhoneNumbers/DataEntry/PhoneNumbersDetailView.swift
+++ b/Sources/SpeziAccountPhoneNumbers/DataEntry/PhoneNumbersDetailView.swift
@@ -107,20 +107,20 @@ struct PhoneNumbersDetailView: View {
     private func row(for phoneNumber: PhoneNumber) -> some View {
         let isProcessing = processingPhoneNumbers.contains(phoneNumber)
         ListRow(verbatim: phoneNumberViewModel.formatPhoneNumberForDisplay(phoneNumber)) {
-            Button(
-                action: { phoneNumberToDelete = phoneNumber },
-                label: {
-                    Image(systemName: "trash.circle.fill")
-                        .resizable()
-                        .accessibilityLabel("Delete Phone Number")
-                        .foregroundStyle(.red)
-                        .frame(width: 32, height: 32)
-                        .padding(-8)
-                }
-            )
-            .processingOverlay(isProcessing: isProcessing)
+            if isProcessing {
+                ProgressView()
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                phoneNumberToDelete = phoneNumber
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
             .disabled(isProcessing)
         }
+        .opacity(isProcessing ? 0.5 : 1.0)
+        .animation(.default, value: isProcessing)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Replaces the inline trash button on each phone number row with a native **swipe-to-delete** gesture, as requested in #100.

## Problem

The previous implementation used a `Button` with a trash icon on each row. The issue noted that `onDelete` (SwiftUI's built-in swipe-to-delete) couldn't be used directly because it immediately removes the row from the UI before the server confirms the deletion — causing a confusing reappear if the deletion fails.

## Solution

This PR uses `.swipeActions(edge: .trailing)` instead of `onDelete`, which provides the familiar swipe gesture without automatically removing the row. The existing confirmation alert + async deletion flow is preserved:

1. **User swipes** → confirmation alert appears
2. **User confirms** → row dims (`opacity: 0.5`) + `ProgressView` appears
3. **Server responds** → row is removed (success) or restored to full opacity (failure) with error alert

### Key UX details

- `allowsFullSwipe: true` — power users can full-swipe for quick deletion
- Swipe is disabled on rows currently being deleted (`.disabled(isProcessing)`)
- Back button is hidden during in-flight deletions (existing behavior preserved)

## Changes

```diff
 // Before: inline trash button
-ListRow(...) {
-    Button(action: { phoneNumberToDelete = phoneNumber }) {
-        Image(systemName: "trash.circle.fill")
-    }
-    .processingOverlay(isProcessing: isProcessing)
-}

 // After: swipe-to-delete
+ListRow(...) {
+    if isProcessing { ProgressView() }
+}
+.swipeActions(edge: .trailing, allowsFullSwipe: true) {
+    Button(role: .destructive) { phoneNumberToDelete = phoneNumber }
+}
+.opacity(isProcessing ? 0.5 : 1.0)
```

## Files Changed

- `Sources/SpeziAccountPhoneNumbers/DataEntry/PhoneNumbersDetailView.swift` — 1 file, +12/-12

Fixes #100